### PR TITLE
Fix DKVMN based loss, labels-predictions mismatch 

### DIFF
--- a/edustudio/model/KT/deep_irt.py
+++ b/edustudio/model/KT/deep_irt.py
@@ -123,7 +123,7 @@ class DeepIRT(GDBaseModel):
             dict: The predictions of the model and the real situation
         """
         y_pd = self(**kwargs)
-        y_pd = y_pd[:, :-1]
+        y_pd = y_pd[:, 1:]
         y_pd = y_pd[kwargs['mask_seq'][:, 1:] == 1]
         y_gt = None
         if kwargs.get('label_seq', None) is not None:
@@ -141,7 +141,7 @@ class DeepIRT(GDBaseModel):
             dict: {'loss_main': loss_value}
         """
         y_pd = self(**kwargs)
-        y_pd = y_pd[:, :-1]
+        y_pd = y_pd[:, 1:]
         y_pd = y_pd[kwargs['mask_seq'][:, 1:] == 1]
         y_gt = kwargs['label_seq'][:, 1:]
         y_gt = y_gt[kwargs['mask_seq'][:, 1:] == 1]

--- a/edustudio/model/KT/dkvmn.py
+++ b/edustudio/model/KT/dkvmn.py
@@ -84,7 +84,7 @@ class DKVMN(GDBaseModel):
     @torch.no_grad()
     def predict(self, **kwargs):
         y_pd = self(**kwargs)
-        y_pd = y_pd[:, :-1]
+        y_pd = y_pd[:, 1:]
         y_pd = y_pd[kwargs['mask_seq'][:, 1:] == 1]
         y_gt = None
         if kwargs.get('label_seq', None) is not None:
@@ -97,7 +97,7 @@ class DKVMN(GDBaseModel):
 
     def get_main_loss(self, **kwargs):
         y_pd = self(**kwargs)
-        y_pd = y_pd[:, :-1]
+        y_pd = y_pd[:, 1:]
         y_pd = y_pd[kwargs['mask_seq'][:, 1:] == 1]
         y_gt = kwargs['label_seq'][:, 1:]
         y_gt = y_gt[kwargs['mask_seq'][:, 1:] == 1]


### PR DESCRIPTION
DKVMN & deepIRT implementations don't need shifting predictions or true labels.